### PR TITLE
Fix for cursor disappearing

### DIFF
--- a/Core_GamepadSupport/Gamepad/CursorEmulator.cs
+++ b/Core_GamepadSupport/Gamepad/CursorEmulator.cs
@@ -70,6 +70,7 @@ namespace KK_GamepadSupport.Gamepad
 
             if (EmulatingCursor())
             {
+                Cursor.visible = false;
                 var rightStick = GamepadWhisperer.GetRightStick();
                 if (rightStick.magnitude > 0)
                 {
@@ -91,6 +92,10 @@ namespace KK_GamepadSupport.Gamepad
                 var scrollAmount = Mathf.RoundToInt(GamepadWhisperer.CurrentState.ThumbSticks.Left.Y * Native.WHEEL_DELTA * Time.deltaTime);
                 if (scrollAmount != 0)
                     Native.mouse_event(Native.MOUSEEVENTF_WHEEL, 0, 0, scrollAmount, 0);
+            }
+            else
+            {
+                Cursor.visible = true;
             }
 
             _previousR = rPressed;

--- a/Core_GamepadSupport/Navigation/CanvasCharmer.cs
+++ b/Core_GamepadSupport/Navigation/CanvasCharmer.cs
@@ -67,6 +67,8 @@ namespace KK_GamepadSupport.Navigation
 
             if (GamepadSupportPlugin.CanvasDebug.Value)
                 DrawCanvasList(currentSelectedGameObject);
+
+            CursorDrawer.DrawMousePointer(Input.mousePosition);
         }
 
         private void Update()

--- a/Core_GamepadSupport/Navigation/CanvasCharmer.cs
+++ b/Core_GamepadSupport/Navigation/CanvasCharmer.cs
@@ -68,7 +68,8 @@ namespace KK_GamepadSupport.Navigation
             if (GamepadSupportPlugin.CanvasDebug.Value)
                 DrawCanvasList(currentSelectedGameObject);
 
-            CursorDrawer.DrawMousePointer(Input.mousePosition);
+            if (!Cursor.visible)
+                CursorDrawer.DrawMousePointer(Input.mousePosition);
         }
 
         private void Update()

--- a/Core_GamepadSupport/Navigation/CursorDrawer.cs
+++ b/Core_GamepadSupport/Navigation/CursorDrawer.cs
@@ -7,10 +7,12 @@ namespace KK_GamepadSupport.Navigation
     public class CursorDrawer
     {
         private Texture2D _pointer;
+        private Texture2D _mousePointer;
 
         public void LoadTexture()
         {
             _pointer = ResourceUtils.GetEmbeddedResource("pointer.png", typeof(CursorDrawer).Assembly).LoadTexture();
+            _mousePointer = ResourceUtils.GetEmbeddedResource("pointer.png", typeof(CursorDrawer).Assembly).LoadTexture();
 
             const int idealResolutionH = 1800;
 
@@ -19,6 +21,9 @@ namespace KK_GamepadSupport.Navigation
                 var scaleFactor = (float)Screen.height / idealResolutionH;
                 TextureScale.Bilinear(_pointer, (int)(_pointer.width * scaleFactor), (int)(_pointer.height * scaleFactor));
                 _pointer.Apply(false);
+
+                TextureScale.Bilinear(_mousePointer, (int)(_mousePointer.width * scaleFactor), (int)(_mousePointer.height * scaleFactor));
+                _mousePointer.Apply(false);
             }
         }
 
@@ -59,6 +64,11 @@ namespace KK_GamepadSupport.Navigation
             }
 
             GUI.Label(new Rect(Mathf.Max(0, pixelPosition.x - _pointer.width) + offset, pixelPosition.y - _pointer.height / 3f, _pointer.width, _pointer.height), _pointer);
+        }
+
+        public void DrawMousePointer(Vector3 mousePosition)
+        {
+            GUI.Label(new Rect(mousePosition.x - _mousePointer.width / 2, Screen.height - mousePosition.y - _mousePointer.height / 2, _mousePointer.width, _mousePointer.height), _mousePointer);
         }
 
         private static Rect RectTransformToScreenSpace(RectTransform transform)


### PR DESCRIPTION
This solution is pretty bad, however much you hate it I hate it so much more. Why would anyone draw another cursor when most operating systems have one right there? However I could not find another way to stop the system cursor from automatically disappearing, also since I don't know how to rip the cursor image from the game or call it I used the pointer included for selection boxes. 

If you want to see the issue this fixes in action, then all you have to do is not move your physical mouse while using the cursor emulator on the release build. You will quickly see that despite the joysticks moving the mouse around, it will disappear. I do not know if this behavior is the same on windows, but its definitely like this on Linux and this is the only way I could think of to fix it. 

I greatly apologize for the travesty of jank this fix brings, but at least with its jank Steam Deck users will no longer have their cursor disappear while using this mod. 